### PR TITLE
remove dockerignore from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.12-slim-bookworm
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.3.3 /uv /bin/uv
 
-# Install the project with intermediate layers
-ADD .dockerignore .
-
 # First, install the dependencies
 WORKDIR /app
 ADD uv.lock /app/uv.lock


### PR DESCRIPTION
We can remove the line `ADD .dockerignore .` from the Dockerfile. The .dockerignore file is only used to exclude files from the build context and doesn’t need to be included in the final image