### PR TITLE
Fix `run.sh` docs to match arguments passed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@
 #   --rm                        Remove the container after exiting
 #   --volume .:/app             Mount the current directory to `/app` so code changes don't require an image rebuild
 #   --volume /app/.venv         Mount the virtual environment separately, so the developer's environment doesn't end up in the container
-#   --expose                    Expose the web server port 8000 to the host
+#   --publish 8000:8000         Expose the web server port 8000 to the host
 #   -it $(docker build -q .)    Build the image, then use it as a run target
 #   $@                          Pass any arguments to the container
 


### PR DESCRIPTION
This PR fixes a slight issue in the documentation in `run.sh`. Open to changing this if needed but otherwise, this is a pretty simple change.
