### PR TITLE
Solve the problem of docker run errors when execute run.sh 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,15 +13,16 @@
 #   -it $(docker build -q .)    Build the image, then use it as a run target
 #   $@                          Pass any arguments to the container
 
+script_path=$(dirname "$(realpath "$0")")
+
 if [ -t 1 ]; then
     INTERACTIVE="-it"
 else
     INTERACTIVE=""
 fi
-
 docker run \
     --rm \
-    --volume .:/app \
+    --volume "${script_path}":/app \
     --volume /app/.venv \
     --publish 8000:8000 \
     $INTERACTIVE \


### PR DESCRIPTION
docker run error message：
docker: Error response from daemon: create ./: "./" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.If you intended to pass a host directory, use absolute path.