### PR TITLE
Copy Python executable from the builder in multistage.Dockerfile

### DIFF
--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -22,6 +22,8 @@ FROM python:3.12-slim-bookworm
 
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
+# Copy Python executable from the builder
+COPY --from=builder --chown=app:app /root/.local/share/uv /root/.local/share/uv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
While trying to reproduce the example using [multistage Dockerfile](https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile), I ran into the following error:

```bash
exec backend/.venv/bin/fastapi: no such file or directory
```

`.dockerignore` file was already configured, so it wasn't copying my local environment. Then, I executed `ls -lah /app/.venv/bin` and got this output:

```bash
total 56K
drwxr-xr-x 2 root root 4.0K Dec 12 18:06 .
drwxr-xr-x 4 root root 4.0K Dec 12 18:06 ..
-rw-r--r-- 1 root root 3.7K Dec 12 18:06 activate
-rw-r--r-- 1 root root 2.2K Dec 12 18:06 activate.bat
-rw-r--r-- 1 root root 2.6K Dec 12 18:06 activate.csh
-rw-r--r-- 1 root root 4.1K Dec 12 18:06 activate.fish
-rw-r--r-- 1 root root 3.8K Dec 12 18:06 activate.nu
-rw-r--r-- 1 root root 2.8K Dec 12 18:06 activate.ps1
-rw-r--r-- 1 root root 2.4K Dec 12 18:06 activate_this.py
-rw-r--r-- 1 root root 1.7K Dec 12 18:06 deactivate.bat
-rwxr-xr-x 1 root root  215 Dec 12 18:06 fastapi
-rw-r--r-- 1 root root 1.2K Dec 12 18:06 pydoc.bat
lrwxrwxrwx 1 root root   76 Dec 12 18:06 python -> /root/.local/share/uv/python/cpython-3.13.1-linux-aarch64-gnu/bin/python3.13
lrwxrwxrwx 1 root root    6 Dec 12 18:06 python3 -> python
lrwxrwxrwx 1 root root    6 Dec 12 18:06 python3.13 -> python
```

I noticed that the example only copies the `/app` directory, so it couldn't find Python executable from `/root/.local/share/uv/python/cpython-3.13.1-linux-aarch64-gnu/bin/python3.13`. Adding the following line to the Dockerfile fixed the problem:

```docker
COPY --from=builder --chown=app:app /root/.local/share/uv /root/.local/share/uv
```