### PR TITLE
Rebuild on `uv.lock` instead of `pyproject.toml`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,6 @@ services:
           ignore:
             - .venv/
 
-        # Rebuild the image on changes to the `pyproject.toml`
+        # Rebuild the image if dependencies change by checking uv.lock
         - action: rebuild
-          path: ./pyproject.toml
+          path: ./uv.lock


### PR DESCRIPTION
`pyproject.toml` includes a lot of meta information alongside dependencies, like lint rules, while `uv.lock` is specific to dependency updates which is what you'd want to track to rebuild the image.