### PR TITLE
use container python interpreter instead of downloading a new one

### DIFF
--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -3,7 +3,7 @@
 # First, build the application in the `/app` directory.
 # See `Dockerfile` for details.
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
-ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON=/usr/local/bin/python
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \


### PR DESCRIPTION
otherwise the second stage breaks - the symlinks point to a non existing managed interpreter