### PR TITLE
Disable `UV_PYTHON_DOWNLOADS` in the multistage image

### DIFF
--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -4,6 +4,12 @@
 # See `Dockerfile` for details.
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+# Disable Python downloads, because we want to use the system interpreter
+# across both images. If using a managed Python version, it needs to be
+# copied from the build image into the final image.
+ENV UV_PYTHON_DOWNLOADS=0
+
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \


### PR DESCRIPTION
Supersedes https://github.com/astral-sh/uv-docker-example/pull/41