### PR TITLE
Patch instruction to copy src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
-ADD . /app
+COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project --no-dev
-ADD . /app
+COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project --no-dev
-ADD . /app
+COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 


### PR DESCRIPTION
## Description
This PR introduces a minor refactor to change the instruction `ADD` to `COPY` across all Dockerfiles. `COPY` promotes Docker's recommendation. This trivial update aligns with this repo's theme of adopting best practices.

### Decisions 

**Note:** Despite `ADD` and `COPY` achieving the same thing, the following are reasons _why_ `COPY` is preferred in this context:
- Explicit: `COPY` is more direct and predictable about its functionality
- Side-effects: `ADD` has _"magic"_ features (compressed file auto-extraction, URL file downloads, etc.) which require extra care.
- Security: Mitigate potential security concerns from `ADD` features (i.e. automatically downloading and extracting remote files.) 

## References
More on `ADD` vs `COPY` from Docker's official [docs](https://docs.docker.com/build/building/best-practices/#add-or-copy).