### PR TITLE
Use non-legacy format to define ENV

### DIFF
--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Configure the Python directory so it is consistent
-ENV UV_PYTHON_INSTALL_DIR /python
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Only use the managed Python version
 ENV UV_PYTHON_PREFERENCE=only-managed


### PR DESCRIPTION
`ENV` should be defined as `ENV key=value`, but one of the `ENV` instruction was using the legacy format `ENV key value`.

This changes addresses this warning:
```
1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 21)
```