### PR TITLE
feat(docker): set default UV_TOOL_BIN_DIR on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
+# Ensure installed tools can be executed out of the box
+ENV UV_TOOL_BIN_DIR=/usr/local/bin
+
 # Install the project's dependencies using the lockfile and settings
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \


### PR DESCRIPTION
Per https://github.com/astral-sh/uv/pull/13391#pullrequestreview-2834464369

The change was not added to standalone or multistage as those don't use uv on the final stage.