### PR TITLE
Set "app" as user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Setup an app user so the container doesn't run as the root user
+RUN useradd app
+USER app
+
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT []
 

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -33,5 +33,9 @@ COPY --from=builder --chown=app:app /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Setup an app user so the container doesn't run as the root user
+RUN useradd app
+USER app
+
 # Run the FastAPI application by default
 CMD ["fastapi", "dev", "--host", "0.0.0.0", "/app/src/uv_docker_example"]

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -34,5 +34,9 @@ COPY --from=builder --chown=app:app /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Setup an app user so the container doesn't run as the root user
+RUN useradd app
+USER app
+
 # Run the FastAPI application by default
 CMD ["fastapi", "dev", "--host", "0.0.0.0", "/app/src/uv_docker_example"]


### PR DESCRIPTION
As described in the official [Writing a Dockerfile](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/) guide, they recommend setting a user, so the container doesn't have root access.

```Dockerfile
# Setup an app user so the container doesn't run as the root user
RUN useradd app
USER app
```