### PR TITLE
refactor: dev-dependencies deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ build-backend = "hatchling.build"
 [project.scripts]
 hello = "uv_docker_example:hello"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff>=0.6.2",
     "fastapi-cli>=0.0.5",
 ]


### PR DESCRIPTION
Per [the UV settings documentation](https://docs.astral.sh/uv/reference/settings/#dev-dependencies), `dev-dependencies` is deprecated and should be replaced with `dependency-groups.dev`.