### PR TITLE
Sync base image directives across multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -1,8 +1,13 @@
 # An example using multi-stage image builds to create a final image without uv.
 
+# Note: spec `major.minor` versions ONLY for uv Python images.
+ARG PYTHON_VERSION=3.12
+ARG DEBIAN_CODENAME=bookworm
+ARG VARIANT=slim
+
 # First, build the application in the `/app` directory.
 # See `Dockerfile` for details.
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-${DEBIAN_CODENAME}-${VARIANT} AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Omit development dependencies
@@ -25,10 +30,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # Then, use a final image without uv
-FROM python:3.12-slim-bookworm
-# It is important to use the image that matches the builder, as the path to the
-# Python executable must be the same, e.g., using `python:3.11-slim-bookworm`
-# will fail.
+FROM python:${PYTHON_VERSION}-${VARIANT}-${DEBIAN_CODENAME}
+# [Important] The image tag format differs between the official Python image and
+# uv-provided images.
+#
+# Official Python image  →  python:<major>.<minor>.<patch>-<variant>-<codename>
+# uv Python image        →  python<major>.<minor>-<codename>-<variant>
+#
+# Do NOT copy-paste tags between the two — they are not interchangeable.
+# Reference the official docs for both definitions.
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -2,7 +2,7 @@
 
 # Note: spec `major.minor` versions ONLY for uv Python images.
 ARG PYTHON_VERSION=3.12
-ARG DEBIAN_CODENAME=bookworm
+ARG DEBIAN_CODENAME=trixie
 ARG VARIANT=slim
 
 # First, build the application in the `/app` directory.

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -3,7 +3,7 @@
 # Define build arguments for Debian codename and variant.
 # These are shared across FROM statements to ensure both stages stay in sync,
 # avoiding subtle runtime failures from mismatched Python environments.
-ARG DEBIAN_CODENAME=bookworm
+ARG DEBIAN_CODENAME=trixie
 ARG VARIANT=slim
 
 # First, build the application in the `/app` directory

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -1,7 +1,13 @@
 # An example of using standalone Python builds with multistage images.
 
+# Define build arguments for Debian codename and variant.
+# These are shared across FROM statements to ensure both stages stay in sync,
+# avoiding subtle runtime failures from mismatched Python environments.
+ARG DEBIAN_CODENAME=bookworm
+ARG VARIANT=slim
+
 # First, build the application in the `/app` directory
-FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:${DEBIAN_CODENAME}-${VARIANT} AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Omit development dependencies
@@ -26,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
 # Then, use a final image without uv
-FROM debian:bookworm-slim
+FROM debian:${DEBIAN_CODENAME}-${VARIANT}
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \


### PR DESCRIPTION
## Description
This PR introduces minor enhancements to:
- Ensure base images in `FROM` statements across multistage `Dockerfiles` remain in sync using build `ARG`s, which is a common idiomatic Docker solution. It's ideal to remove this responsibility from users; depending on human effort, despite the existing comment acting as a safeguard.
```Dockerfile
Comment:
# It is important to use the image that matches the builder...
``` 

### Additional
I noticed the base image used in the examples, `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`, is not in the `uv` docs list of [available images](https://docs.astral.sh/uv/guides/integration/docker/#available-images). I don't think `bookworm` has been dropped yet, but `trixie` has been promoted to the default tag (see references). Hence, the following change:
- Update base image OS versions (Debian) from `bookworm` to `trixie`.
> 🛈 This has advantages, such as fewer HIGH security vulnerabilities (CVEs) compared to Debian 12 (`bookworm`). 

## References
Relevant Issues/PRs related to `Debian` versions:
- https://github.com/astral-sh/uv/issues/15270
- https://github.com/astral-sh/uv/pull/15269
- https://github.com/astral-sh/uv/pull/15352