### PR TITLE
Force the stdout and stderr streams to be unbuffered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN groupadd --system --gid 999 nonroot \
 # Install the project into `/app`
 WORKDIR /app
 
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -40,6 +40,10 @@ COPY --from=builder --chown=nonroot:nonroot /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
 # Use the non-root user to run our application
 USER nonroot
 

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -41,6 +41,10 @@ COPY --from=builder --chown=nonroot:nonroot /app /app
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
 # Use the non-root user to run our application
 USER nonroot
 


### PR DESCRIPTION
As suggested in the official docker [Containerize a Python application](https://docs.docker.com/guides/python/containerize/#create-docker-assets) example, force the stdout and stderr streams to be unbuffered by setting [`PYTHONUNBUFFERED=1`](https://docs.python.org/3/using/cmdline.html#cmdoption-u).

This will ensure that any program will directly write its output to the docker logs.