### PR TITLE
feat(docker): bookworm -> trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -2,7 +2,7 @@
 
 # First, build the application in the `/app` directory.
 # See `Dockerfile` for details.
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Omit development dependencies
@@ -25,9 +25,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 # Then, use a final image without uv
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-trixie
 # It is important to use the image that matches the builder, as the path to the
-# Python executable must be the same, e.g., using `python:3.11-slim-bookworm`
+# Python executable must be the same, e.g., using `python:3.11-slim-trixie`
 # will fail.
 
 # Setup a non-root user

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -1,7 +1,7 @@
 # An example of using standalone Python builds with multistage images.
 
 # First, build the application in the `/app` directory
-FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:trixie-slim AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Omit development dependencies
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
 # Then, use a final image without uv
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \


### PR DESCRIPTION
Closes #88 

The best practice that uv supports is trixie instead of bookworm. 
It is also confusing for users to go to https://docs.astral.sh/uv/guides/integration/docker/ and not see any bookworm images available. 