### PR TITLE
Harden Docker examples: high UID, narrower context, non-editable installs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,17 @@
 # Exclude the project virtual environment from image builds
 .venv
+
+# VCS / CI / local tooling — not needed in the image
+.git
+.github
+.gitignore
+
+# Docker and compose files
+Dockerfile
+*.Dockerfile
+compose.yml
+compose.yaml
+
+# Licenses and helper scripts (README.md is kept — hatchling needs it)
+LICENSE*
+run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,14 @@ ENV UV_TOOL_BIN_DIR=/usr/local/bin
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-install-project
 
-# Then, add the rest of the project source code and install it
+# Then, add the project metadata and source and install it
 # Installing separately from its dependencies allows optimal layer caching
-COPY . /app
+# (dev image keeps an editable install and project files for bind mounts / `uv run`)
+COPY pyproject.toml README.md uv.lock ./
+COPY src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Use a Python image with uv pre-installed
 FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim
 
-# Setup a non-root user
-RUN groupadd --system --gid 999 nonroot \
- && useradd --system --gid 999 --uid 999 --create-home nonroot
+# Setup a non-root user with a high UID to avoid host collisions
+RUN groupadd --gid 10001 app \
+ && useradd --uid 10001 --gid 10001 --create-home --home-dir /home/app app
 
 # Install the project into `/app`
 WORKDIR /app
@@ -43,7 +43,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENTRYPOINT []
 
 # Use the non-root user to run our application
-USER nonroot
+USER 10001
 
 # Run the FastAPI application by default
 # Uses `uv run` to sync dependencies on startup, respecting UV_NO_DEV

--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ The [`Dockerfile`](./Dockerfile) defines the image and includes:
 
 - Installation of uv
 - Installing the project dependencies and the project separately for optimal image build caching
+- A high non-root UID (`10001`) for the default runtime user
 - Placing environment executables on the `PATH`
 - Running the web application in development mode
 
 The [`multistage.Dockerfile`](./multistage.Dockerfile) example extends the `Dockerfile` example to
-use multistage builds to reduce the final size of the image. This image runs the application in
-production mode.
+use multistage builds to reduce the final size of the image. It installs the project with
+`--no-editable`, copies only the virtual environment into the final stage, and runs the app via
+`uvicorn` against the installed package. This image runs the application in production mode.
 
 The [`standalone.Dockerfile`](./standalone.Dockerfile) example extends the `multistage.Dockerfile`
 example to use a managed Python interpreter in a multistage build instead of the system interpreter
@@ -112,4 +114,10 @@ To build the multistage image:
 
 ```console
 $ docker build . --file multistage.Dockerfile
+```
+
+To build the standalone (managed Python) image:
+
+```console
+$ docker build . --file standalone.Dockerfile
 ```

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ that comes with the base image. This image runs the application in production mo
 
 ### Dockerignore file
 
-The [`.dockerignore`](./.dockerignore) file includes an entry for the `.venv` directory to ensure the
-`.venv` is not included in image builds. Note that the `.dockerignore` file is not applied to volume
-mounts during container runs.
+The [`.dockerignore`](./.dockerignore) file excludes the `.venv` directory and other non-application
+files (git metadata, Docker/compose config, licenses, helper scripts) from image builds. Note that
+the `.dockerignore` file is not applied to volume mounts during container runs.
 
 ### Run script
 

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -18,10 +18,13 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
-COPY . /app
+    uv sync --locked --no-install-project --no-editable
+
+# Copy only what is needed to build/install the project
+COPY pyproject.toml README.md uv.lock ./
+COPY src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked
+    uv sync --locked --no-editable
 
 
 # Then, use a final image without uv
@@ -30,12 +33,12 @@ FROM python:3.12-slim-trixie
 # Python executable must be the same, e.g., using `python:3.11-slim-trixie`
 # will fail.
 
-# Setup a non-root user
-RUN groupadd --system --gid 999 nonroot \
- && useradd --system --gid 999 --uid 999 --create-home nonroot
+# Setup a non-root user with a high UID to avoid host collisions
+RUN groupadd --gid 10001 app \
+ && useradd --uid 10001 --gid 10001 --create-home --home-dir /home/app app
 
-# Copy the application from the builder
-COPY --from=builder --chown=nonroot:nonroot /app /app
+# Copy the virtual environment only (non-editable install; no source tree needed)
+COPY --from=builder --chown=10001:10001 /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
@@ -45,10 +48,10 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 
 # Use the non-root user to run our application
-USER nonroot
+USER 10001
 
 # Use `/app` as the working directory
 WORKDIR /app
 
-# Run the FastAPI application by default
-CMD ["fastapi", "run", "--host", "0.0.0.0", "src/uv_docker_example"]
+# Run the FastAPI application by default (installed package, not source path)
+CMD ["uvicorn", "uv_docker_example:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -18,12 +18,15 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-install-project --no-editable
 
 # Copy only what is needed to build/install the project
-COPY pyproject.toml README.md uv.lock ./
 COPY src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-editable
 
 
@@ -39,6 +42,9 @@ RUN groupadd --gid 10001 app \
 
 # Copy the virtual environment only (non-editable install; no source tree needed)
 COPY --from=builder --chown=10001:10001 /app/.venv /app/.venv
+
+# If the source tree is needed, copy it from the builder image
+# COPY --from=builder --chown=10001:10001 /app/src/ /app/src/
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -20,23 +20,31 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
-COPY . /app
+    uv sync --locked --no-install-project --no-editable
+
+# Copy only what is needed to build/install the project
+COPY pyproject.toml README.md uv.lock ./
+COPY src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked
+    uv sync --locked --no-editable
 
 # Then, use a final image without uv
 FROM debian:trixie-slim
 
-# Setup a non-root user
-RUN groupadd --system --gid 999 nonroot \
- && useradd --system --gid 999 --uid 999 --create-home nonroot
+# Setup a non-root user with a high UID to avoid host collisions
+RUN groupadd --gid 10001 app \
+ && useradd --uid 10001 --gid 10001 --create-home --home-dir /home/app app
+
+# Install CA certificates for outbound TLS (e.g. HTTPS clients)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy the Python version
 COPY --from=builder /python /python
 
-# Copy the application from the builder
-COPY --from=builder --chown=nonroot:nonroot /app /app
+# Copy the virtual environment only (non-editable install; no source tree needed)
+COPY --from=builder --chown=10001:10001 /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
@@ -46,10 +54,10 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 
 # Use the non-root user to run our application
-USER nonroot
+USER 10001
 
 # Use `/app` as the working directory
 WORKDIR /app
 
-# Run the FastAPI application by default
-CMD ["fastapi", "run", "--host", "0.0.0.0", "src/uv_docker_example"]
+# Run the FastAPI application by default (installed package, not source path)
+CMD ["uvicorn", "uv_docker_example:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -38,11 +38,6 @@ FROM debian:trixie-slim
 RUN groupadd --gid 10001 app \
  && useradd --uid 10001 --gid 10001 --create-home --home-dir /home/app app
 
-# Install CA certificates for outbound TLS (e.g. HTTPS clients)
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
- && rm -rf /var/lib/apt/lists/*
-
 # Copy the Python version
 COPY --from=builder /python /python
 

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -20,12 +20,15 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-install-project --no-editable
 
 # Copy only what is needed to build/install the project
-COPY pyproject.toml README.md uv.lock ./
 COPY src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-editable
 
 # Then, use a final image without uv
@@ -45,6 +48,9 @@ COPY --from=builder /python /python
 
 # Copy the virtual environment only (non-editable install; no source tree needed)
 COPY --from=builder --chown=10001:10001 /app/.venv /app/.venv
+
+# If the source tree is needed, copy it from the builder image
+# COPY --from=builder --chown=10001:10001 /app/src/ /app/src/
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
First of all- thanks for providing this!
I hope this all makes sense, happy to slim it down to help focus if needed.

The main concern I had was the copy of the entire project into the image. This narrows it down to ./src

The other items are what I use for best practices on my own containers. I had AI review my logic to verify that this implementation would benefit.

## Summary
- Raise the runtime user from UID/GID `999` to `10001` (numeric `USER`) across example Dockerfiles to reduce host/container UID collisions.
- Expand `.dockerignore` and copy only application `src` (plus bind-mounted project metadata during `uv sync`) instead of `COPY . /app`.
- Use `--no-editable` installs in multistage/standalone so the final image copies only `.venv` (and managed Python for standalone); run via `uvicorn uv_docker_example:app`. Includes a commented tip for copying `/app/src` when a path-based entrypoint needs it.
- README updated for the new patterns.

## Test plan
- [x] `docker build -f standalone.Dockerfile -t uv-docker-example:standalone .`
- [x] `docker run --rm -p 8000:8000 …` → `GET /` returns `"Hello world"` as UID `10001`
- [x] `docker build -f multistage.Dockerfile -t uv-docker-example:multistage .`
- [x] Multistage container serves `"Hello world"` on `/`